### PR TITLE
Update MSBuild.StructuredLogger to 2.1.472

### DIFF
--- a/MSBuildBinLogSummary/MSBuildBinLogSummary.csproj
+++ b/MSBuildBinLogSummary/MSBuildBinLogSummary.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.404" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.472" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20303.1" />
   </ItemGroup>
 

--- a/MSBuildBinLogSummary/StructuredLoggerUtil.cs
+++ b/MSBuildBinLogSummary/StructuredLoggerUtil.cs
@@ -75,6 +75,11 @@ namespace MSBuildBinLogSummarizer
 
         private void RecordProperties(IEnumerable properties)
         {
+            if (properties == null)
+            {
+                return;
+            }
+
             foreach (KeyValuePair<string,string> property in properties)
             {
                 if (!RemoveVersionSpecificNames(property.Key.ToString()) && !RemoveVersionSpecificValues(property.Value.ToString()))
@@ -86,6 +91,11 @@ namespace MSBuildBinLogSummarizer
 
         private void RecordItems(IEnumerable items)
         {
+            if (items == null)
+            {
+                return;
+            }
+
             foreach (DictionaryEntry item in items)
             {
                 if (!RemoveVersionSpecificNames(item.Key.ToString()))


### PR DESCRIPTION
The new package properly initializes Message fields for those arguments that don't serialize it. MSBuild itself can now recover the Message on demand so we mimic what MSBuild does.

Fix nullrefs. It is expected that both Properties and Items can be null.